### PR TITLE
Add test coverage for exact match disambiguation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+mutants.out/

--- a/tests/snapshots/recipe__exact_match_disambiguates_substring.snap
+++ b/tests/snapshots/recipe__exact_match_disambiguates_substring.snap
@@ -1,0 +1,16 @@
+---
+source: tests/recipe.rs
+expression: snapshot_content
+---
+Available recipes: rice, rice-bowl
+$ nutriterm recipe rice
+Recipe: rice
+
+╭─────────────────────┬──────────┬─────────────┬───────────┬───────┬─────────┬────────────╮
+│  Name               │  Weight  │  Net carbs  │  Protein  │  Fat  │  Fiber  │  Calories  │
+├─────────────────────┼──────────┼─────────────┼───────────┼───────┼─────────┼────────────┤
+│ White Rice (cooked) │  200.0 g │      56.0 g │     5.4 g │ 0.6 g │   0.8 g │   251 kcal │
+│               Total │  200.0 g │      56.0 g │     5.4 g │ 0.6 g │   0.8 g │   251 kcal │
+╰─────────────────────┴──────────┴─────────────┴───────────┴───────┴─────────┴────────────╯
+
+200.0 g  White Rice (cooked)


### PR DESCRIPTION
## Summary
- Add test coverage for recipe search exact match functionality to fix missed mutation testing
- Add mutants.out/ to .gitignore to avoid committing mutation test artifacts

## Problem Solved
Mutation testing revealed that `find_exact_match` function was not properly tested. The mutant `replace find_exact_match -> Option<&'a Recipe> with None` was missed because existing tests produced identical results whether exact match worked or failed.

## Solution
Added `test_exact_match_disambiguates_substring_conflicts()` which creates a scenario where exact match is essential:
- Recipes: "rice" and "rice-bowl" 
- Search: "rice"
- Expected: Shows "rice" recipe (exact match succeeds)
- Without exact match: Would show "Multiple recipes found" ambiguity error

This test will now catch the previously missed mutant, proving that exact match serves as a critical disambiguation mechanism when recipe names have substring relationships.

## Changes
- **tests/recipe.rs**: Add test case with substring conflicting recipe names
- **tests/snapshots/**: Add corresponding snapshot for new test
- **.gitignore**: Add mutants.out/ directory to ignore list