### PR TITLE
Remove unused std::error::Error implementation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -165,15 +165,7 @@ impl std::fmt::Display for AppError {
     }
 }
 
-impl std::error::Error for AppError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            AppError::Data(err) => Some(err),
-            AppError::Io(err) => Some(err),
-            _ => None,
-        }
-    }
-}
+
 
 impl From<LoadError> for AppError {
     fn from(err: LoadError) -> Self {


### PR DESCRIPTION
## Summary

• Remove unused std::error::Error implementation for AppError identified by mutation testing
• Eliminate dead code that provides no functional value since error chaining is never used