### PR TITLE
Add mutation testing artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 /target
 **/*.rs.bk
 Cargo.lock
+
+# Mutation testing output directories (cargo-mutants)
+# Contains test results, logs, and diff files from mutation testing runs
 mutants.out/
+mutants.out.old/


### PR DESCRIPTION
## Summary

• Add mutants.out.old/ directory to .gitignore to exclude mutation testing artifacts from version control
• Organize mutation testing entries with clear documentation explaining their purpose