### PR TITLE
Document acceptable mutation testing false positive

### DIFF
--- a/src/utils/suggestions.rs
+++ b/src/utils/suggestions.rs
@@ -19,6 +19,7 @@ pub fn find_best_suggestion(target: &str, candidates: &[String]) -> Option<Strin
         // Only suggest if the distance is reasonable (not more than half the length)
         let max_distance = std::cmp::max(target.len(), candidate.len()) / 2;
 
+        // Note: mutants may change < to <= here, but we don't care whether ties return first or last candidate
         if distance < best_distance && distance <= max_distance {
             best_distance = distance;
             best_suggestion = Some(candidate.clone());
@@ -66,4 +67,8 @@ mod tests {
             None
         );
     }
+
+
+
+
 }


### PR DESCRIPTION
## Summary

• Add comment explaining that the `< to <=` mutation in suggestion algorithm is acceptable
• Documents why tie-breaking behavior (first vs last candidate with equal distance) doesn't matter functionally

## Context

Mutation testing flagged this line as a missed mutant:
```
src/utils/suggestions.rs:22:21: replace < with <= in find_best_suggestion
```

The mutation would change which candidate is returned when multiple candidates have identical Levenshtein distances. Since both candidates are equally good suggestions, we don't care about this behavioral difference.

## Changes

Added explanatory comment to document this design decision for future mutation testing reviews.