### PR TITLE
Improve error type naming for clearer distinction

### DIFF
--- a/src/data/loader.rs
+++ b/src/data/loader.rs
@@ -55,7 +55,7 @@ fn validate_with_schema(
             .map(|error| format!("- {}: {}", error.instance_path, error))
             .collect();
 
-        return Err(LoadError::SchemaValidationError {
+        return Err(LoadError::SchemaViolationError {
             filename: filename.to_string(),
             errors: error_messages,
         });
@@ -86,14 +86,14 @@ fn load_jsonc_file<T: DeserializeOwned>(
         })?;
 
     let schema_json = schema_generator();
-    let schema = Validator::new(&schema_json).map_err(|e| LoadError::ValidationError {
+    let schema = Validator::new(&schema_json).map_err(|e| LoadError::ProcessingError {
         filename: filename.to_string(),
         message: format!("Failed to compile schema: {}", e),
     })?;
 
     validate_with_schema(&json_value, &schema, filename)?;
 
-    serde_json::from_value(json_value).map_err(|e| LoadError::ValidationError {
+    serde_json::from_value(json_value).map_err(|e| LoadError::ProcessingError {
         filename: filename.to_string(),
         message: format!("{}", e),
     })

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,11 +16,11 @@ pub enum LoadError {
         filename: String,
         message: String,
     },
-    ValidationError {
+    ProcessingError {
         filename: String,
         message: String,
     },
-    SchemaValidationError {
+    SchemaViolationError {
         filename: String,
         errors: Vec<String>,
     },
@@ -55,10 +55,10 @@ impl std::fmt::Display for LoadError {
                     filename, message
                 )
             }
-            LoadError::ValidationError { filename, message } => {
+            LoadError::ProcessingError { filename, message } => {
                 write!(f, "Invalid {} structure: {}", filename, message)
             }
-            LoadError::SchemaValidationError { filename, errors } => {
+            LoadError::SchemaViolationError { filename, errors } => {
                 write!(
                     f,
                     "Schema validation failed for {}:\n{}\n\nTip: Check the values against the expected data types and ranges. Use 'nutriterm init' to see example file formats.",


### PR DESCRIPTION
## Summary

• Rename `ValidationError` → `ProcessingError` for schema compilation and deserialization issues
• Rename `SchemaValidationError` → `SchemaViolationError` to emphasize data violates schema rules
• Update all usages in data loader to use the new error types

## Problem

The previous naming was confusing because both errors contained "Validation" in the name:
- `ValidationError` - Used for schema compilation failures and deserialization errors
- `SchemaValidationError` - Used when data violates schema constraints

This made it unclear which was for technical/processing issues vs. data rule violations.

## Solution

**New Error Types:**
- `ProcessingError` - Schema compilation failures, JSON deserialization issues
- `SchemaViolationError` - Data from files violates schema rules/constraints

**Clarity Benefits:**
- `ProcessingError` clearly indicates technical/system issues
- `SchemaViolationError` emphasizes that persisted data violates schema rules
- Distinction helps users understand whether it's a data problem or system issue

## Error Usage

**ProcessingError (technical issues):**
- Schema compilation failures: "Failed to compile schema: ..."  
- Deserialization errors after schema validation passes
- System/format problems

**SchemaViolationError (data rule violations):**
- Data doesn't match schema types, ranges, constraints
- Multiple validation errors with detailed paths
- User-fixable data issues

## Testing

✅ All 49 tests pass after renaming
✅ No functional changes - only improved naming clarity