### PR TITLE
Add kitchen-ref command for printable recipe reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,16 @@ nutriterm kitchen-ref
 
 **Create a PDF for printing:**
 ```bash
-# Requires pandoc (install with your package manager)
+# Option 1: Direct PDF via pandoc (requires LaTeX)
 nutriterm kitchen-ref | pandoc -o kitchen-reference.pdf
+
+# Option 2: Via HTML (more reliable, no LaTeX needed)
+nutriterm kitchen-ref | pandoc -t html -s -o kitchen-reference.html
+# Then open kitchen-reference.html in your browser and print to PDF
+
+# Option 3: HTML to PDF with wkhtmltopdf
+# Install wkhtmltopdf with your package manager first
+nutriterm kitchen-ref | pandoc -t html -s | wkhtmltopdf - kitchen-reference.pdf
 ```
 
 **Example output:**

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Terminal-based nutrition calculator for recipes. A Rust CLI application that cal
 - **Calculate Nutrition** - Get detailed nutritional breakdown for any recipe including net carbs, protein, fat, fiber, and calories
 - **Multiple Ingredients** - Create recipes with multiple ingredients and see combined nutritional values
 - **Easy Recipe Management** - List all your recipes and view nutrition for specific ones
+- **Kitchen Reference** - Generate a printable markdown reference with all recipes and ingredient weights
 - **Smart Workspace** - Works from any directory - automatically finds your recipe data like git does
 - **Human-Readable Format** - Uses JSONC (JSON with comments) so you can easily read and edit your data files
 
@@ -108,10 +109,50 @@ nutriterm recipe "Grilled Chicken with Rice"
 # Search with multiple terms (finds recipes containing ALL terms)
 nutriterm recipe chicken rice  # Finds recipes with both "chicken" AND "rice" in name
 
+# Generate kitchen reference with all recipes (great for printing)
+nutriterm kitchen-ref
+
 # The tool works from anywhere in your recipe directory tree
 cd subfolder
 nutriterm list-recipes  # Still works!
 ```
+
+### Kitchen Reference
+
+Generate a clean markdown reference of all your recipes with ingredient weights:
+
+```bash
+nutriterm kitchen-ref
+```
+
+**Create a PDF for printing:**
+```bash
+# Requires pandoc (install with your package manager)
+nutriterm kitchen-ref | pandoc -o kitchen-reference.pdf
+```
+
+**Example output:**
+```markdown
+# Kitchen Reference
+
+## Chicken Rice Bowl
+
+- 150.0 g  Chicken Breast (skinless)
+- 100.0 g  Brown Rice (cooked)
+- 80.0 g  Broccoli (steamed)
+
+## Greek Salad
+
+- 100.0 g  Mixed Greens
+- 50.0 g  Feta Cheese
+- 75.0 g  Cherry Tomatoes
+- 60.0 g  Cucumber
+```
+
+This is perfect for:
+- **Printing** for kitchen reference while cooking
+- **Shopping lists** when you know the recipes you want to make
+- **Recipe sharing** in a clean, readable format
 
 ### Tips
 
@@ -219,7 +260,7 @@ cargo fmt
 - `src/data/loader.rs` - JSONC loading, parsing, and validation with comprehensive error handling
 - `src/schema/generator.rs` - JSON schema generation for IDE autocompletion support
 - `src/workspace.rs` - Workspace detection and validation logic
-- `src/commands/` - Command implementations (init, recipe, list-recipes)
+- `src/commands/` - Command implementations (init, recipe, list-recipes, kitchen-ref)
 - `src/display/nutrition.rs` - Nutrition table formatting and display logic
 - `src/error.rs` - Centralized error handling and user-friendly error messages
 

--- a/src/commands/kitchen_ref.rs
+++ b/src/commands/kitchen_ref.rs
@@ -1,0 +1,26 @@
+use crate::data::loader;
+use crate::error::AppResult;
+use std::path::Path;
+
+pub fn handle_kitchen_ref_command(data_dir: &Path) -> AppResult<()> {
+    let recipes = loader::load_recipes(data_dir)?;
+
+    println!("# Kitchen Reference");
+    println!();
+
+    for recipe in &recipes {
+        println!("## {}", recipe.name);
+        println!();
+
+        for ingredient in &recipe.ingredients {
+            println!(
+                "- {:.1} g  {}",
+                ingredient.grams, ingredient.ingredient.name
+            );
+        }
+
+        println!();
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod init;
+pub mod kitchen_ref;
 pub mod list_recipes;
 pub mod recipe;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,8 @@ enum Commands {
     },
     #[command(about = "List all available recipes")]
     ListRecipes,
+    #[command(about = "Generate kitchen reference with all recipes in markdown format")]
+    KitchenRef,
 }
 
 fn run_app() -> AppResult<()> {
@@ -47,6 +49,10 @@ fn run_app() -> AppResult<()> {
         Commands::ListRecipes => {
             let workspace = find_workspace()?;
             commands::list_recipes::handle_list_recipes_command(&workspace)?;
+        }
+        Commands::KitchenRef => {
+            let workspace = find_workspace()?;
+            commands::kitchen_ref::handle_kitchen_ref_command(&workspace)?;
         }
     }
     Ok(())

--- a/tests/kitchen_ref.rs
+++ b/tests/kitchen_ref.rs
@@ -1,0 +1,162 @@
+mod common;
+
+use assert_cmd::Command;
+use common::{temp_dir, workspace_dir, normalize_temp_paths};
+use std::fs;
+use insta::assert_snapshot;
+
+#[test]
+fn test_kitchen_ref_outside_workspace() {
+    let temp = temp_dir();
+    let outside_dir = workspace_dir(&temp, "outside");
+
+    let mut cmd = Command::cargo_bin("nutriterm").unwrap();
+    let assert = cmd
+        .current_dir(&outside_dir)
+        .arg("kitchen-ref")
+        .assert()
+        .failure();
+        
+    let output = assert.get_output();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let normalized_stderr = normalize_temp_paths(&stderr, temp.path());
+    assert_snapshot!("no_workspace", normalized_stderr);
+}
+
+fn create_kitchen_ref_workspace(workspace_dir: &std::path::Path) {
+    fs::write(
+        workspace_dir.join("recipes.jsonc"),
+        r#"{
+  "$schema": "./recipes.schema.json",
+  
+  "recipes": [
+    {
+      "name": "Chicken Rice Bowl",
+      "description": "A balanced meal with protein, carbs, and vegetables",
+      "ingredients": [
+        {
+          "ingredient_id": "chicken_breast",
+          "grams": 150
+        },
+        {
+          "ingredient_id": "brown_rice",
+          "grams": 100
+        },
+        {
+          "ingredient_id": "broccoli",
+          "grams": 80
+        }
+      ]
+    },
+    {
+      "name": "Greek Salad",
+      "description": "Fresh Mediterranean salad with feta and olives",
+      "ingredients": [
+        {
+          "ingredient_id": "mixed_greens",
+          "grams": 100
+        },
+        {
+          "ingredient_id": "feta_cheese",
+          "grams": 50
+        },
+        {
+          "ingredient_id": "cherry_tomatoes",
+          "grams": 75
+        },
+        {
+          "ingredient_id": "cucumber",
+          "grams": 60
+        }
+      ]
+    }
+  ]
+}"#,
+    )
+    .unwrap();
+
+    fs::write(
+        workspace_dir.join("ingredients.jsonc"),
+        r#"{
+  "$schema": "./ingredients.schema.json",
+  
+  "ingredients": [
+    {
+      "id": "chicken_breast",
+      "name": "Chicken Breast (skinless)",
+      "carbs_per_100g": 0,
+      "protein_per_100g": 31,
+      "fat_per_100g": 3.6,
+      "fiber_per_100g": 0
+    },
+    {
+      "id": "brown_rice",
+      "name": "Brown Rice (cooked)",
+      "carbs_per_100g": 23,
+      "protein_per_100g": 2.6,
+      "fat_per_100g": 0.9,
+      "fiber_per_100g": 1.8
+    },
+    {
+      "id": "broccoli",
+      "name": "Broccoli (steamed)",
+      "carbs_per_100g": 7,
+      "protein_per_100g": 3,
+      "fat_per_100g": 0.4,
+      "fiber_per_100g": 2.6
+    },
+    {
+      "id": "mixed_greens",
+      "name": "Mixed Greens",
+      "carbs_per_100g": 2,
+      "protein_per_100g": 1.5,
+      "fat_per_100g": 0.2,
+      "fiber_per_100g": 1.2
+    },
+    {
+      "id": "feta_cheese",
+      "name": "Feta Cheese",
+      "carbs_per_100g": 4,
+      "protein_per_100g": 14,
+      "fat_per_100g": 21,
+      "fiber_per_100g": 0
+    },
+    {
+      "id": "cherry_tomatoes",
+      "name": "Cherry Tomatoes",
+      "carbs_per_100g": 4,
+      "protein_per_100g": 0.9,
+      "fat_per_100g": 0.2,
+      "fiber_per_100g": 1.2
+    },
+    {
+      "id": "cucumber",
+      "name": "Cucumber",
+      "carbs_per_100g": 4,
+      "protein_per_100g": 0.7,
+      "fat_per_100g": 0.1,
+      "fiber_per_100g": 0.5
+    }
+  ]
+}"#,
+    )
+    .unwrap();
+}
+
+#[test]  
+fn test_kitchen_ref_success() {
+    let temp = temp_dir();
+    let workspace = workspace_dir(&temp, "workspace");
+    create_kitchen_ref_workspace(&workspace);
+
+    let mut cmd = Command::cargo_bin("nutriterm").unwrap();
+    let assert = cmd
+        .current_dir(&workspace)
+        .arg("kitchen-ref")
+        .assert()
+        .success();
+
+    let output = assert.get_output();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_snapshot!("markdown_output", stdout);
+}

--- a/tests/snapshots/cli__help_output.snap
+++ b/tests/snapshots/cli__help_output.snap
@@ -10,6 +10,7 @@ Commands:
   init          Initialize current directory as a recipe workspace
   recipe        Display nutrition for a specific recipe
   list-recipes  List all available recipes
+  kitchen-ref   Generate kitchen reference with all recipes in markdown format
   help          Print this message or the help of the given subcommand(s)
 
 Options:

--- a/tests/snapshots/cli__no_subcommand_error.snap
+++ b/tests/snapshots/cli__no_subcommand_error.snap
@@ -10,6 +10,7 @@ Commands:
   init          Initialize current directory as a recipe workspace
   recipe        Display nutrition for a specific recipe
   list-recipes  List all available recipes
+  kitchen-ref   Generate kitchen reference with all recipes in markdown format
   help          Print this message or the help of the given subcommand(s)
 
 Options:

--- a/tests/snapshots/kitchen_ref__markdown_output.snap
+++ b/tests/snapshots/kitchen_ref__markdown_output.snap
@@ -1,0 +1,18 @@
+---
+source: tests/kitchen_ref.rs
+expression: stdout
+---
+# Kitchen Reference
+
+## Chicken Rice Bowl
+
+- 150.0 g  Chicken Breast (skinless)
+- 100.0 g  Brown Rice (cooked)
+- 80.0 g  Broccoli (steamed)
+
+## Greek Salad
+
+- 100.0 g  Mixed Greens
+- 50.0 g  Feta Cheese
+- 75.0 g  Cherry Tomatoes
+- 60.0 g  Cucumber

--- a/tests/snapshots/kitchen_ref__no_workspace.snap
+++ b/tests/snapshots/kitchen_ref__no_workspace.snap
@@ -1,0 +1,7 @@
+---
+source: tests/kitchen_ref.rs
+expression: normalized_stderr
+---
+Error: Not in a nutrition calculator workspace (or any parent directory)
+Searched: [TEMP_DIR]/outside, [TEMP_DIR], /tmp, /
+Run 'nutriterm init' to create a workspace.


### PR DESCRIPTION
## Summary

- Implements `nutriterm kitchen-ref` command that generates markdown reference with all recipes and ingredient weights
- Provides clean, printable format perfect for kitchen use and recipe sharing
- Includes comprehensive tests with snapshot validation

Closes #9