### PR TITLE
Standardize human-friendly recipe names across all tests

### DIFF
--- a/tests/common.rs
+++ b/tests/common.rs
@@ -106,7 +106,7 @@ pub fn create_workspace_files(workspace_dir: &std::path::Path) {
   
   "recipes": [
     {
-      "name": "chicken-rice-bowl",
+      "name": "Chicken Rice Bowl",
       "description": "A balanced meal with protein, carbs, and vegetables",
       "ingredients": [
         {

--- a/tests/list_recipes.rs
+++ b/tests/list_recipes.rs
@@ -40,7 +40,7 @@ fn test_in_valid_workspace() {
     let output = assert.get_output();
     let stdout = String::from_utf8_lossy(&output.stdout);
     let snapshot_content = format_list_test_snapshot(
-        &["chicken-rice-bowl"],
+        &["Chicken Rice Bowl"],
         &[], // No additional args for basic list-recipes
         &stdout,
     );

--- a/tests/recipe.rs
+++ b/tests/recipe.rs
@@ -24,7 +24,7 @@ fn test_view_valid_recipe() {
     // User views nutrition for valid recipe
     let assert = Command::cargo_bin("nutriterm")
         .unwrap()
-        .args(&["recipe", "chicken-rice-bowl"])
+        .args(&["recipe", "Chicken Rice Bowl"])
         .current_dir(&workspace_dir)
         .assert()
         .success();
@@ -32,7 +32,7 @@ fn test_view_valid_recipe() {
     let output = assert.get_output();
     let stdout = String::from_utf8_lossy(&output.stdout);
     let snapshot_content =
-        format_test_snapshot(&["chicken-rice-bowl"], "chicken-rice-bowl", &stdout);
+        format_test_snapshot(&["Chicken Rice Bowl"], "Chicken Rice Bowl", &stdout);
     assert_snapshot!("nutrition_display", snapshot_content);
 }
 
@@ -51,7 +51,7 @@ fn test_view_invalid_recipe() {
     let output = assert.get_output();
     let stdout = String::from_utf8_lossy(&output.stdout);
     let snapshot_content =
-        format_test_snapshot(&["chicken-rice-bowl"], "nonexistent-recipe", &stdout);
+        format_test_snapshot(&["Chicken Rice Bowl"], "nonexistent-recipe", &stdout);
     assert_snapshot!("not_found_with_suggestions", snapshot_content);
 }
 
@@ -99,7 +99,7 @@ fn test_search_exact_match() {
     // User searches with exact recipe name - should work as before
     let assert = Command::cargo_bin("nutriterm")
         .unwrap()
-        .args(&["recipe", "chicken-rice-bowl"])
+        .args(&["recipe", "Chicken Rice Bowl"])
         .current_dir(&workspace_dir)
         .assert()
         .success();
@@ -107,7 +107,7 @@ fn test_search_exact_match() {
     let output = assert.get_output();
     let stdout = String::from_utf8_lossy(&output.stdout);
     let snapshot_content =
-        format_test_snapshot(&["chicken-rice-bowl"], "chicken-rice-bowl", &stdout);
+        format_test_snapshot(&["Chicken Rice Bowl"], "Chicken Rice Bowl", &stdout);
     assert_snapshot!("search_exact_match", snapshot_content);
 }
 
@@ -125,7 +125,7 @@ fn test_search_substring_match() {
 
     let output = assert.get_output();
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let snapshot_content = format_test_snapshot(&["chicken-rice-bowl"], "chicken", &stdout);
+    let snapshot_content = format_test_snapshot(&["Chicken Rice Bowl"], "chicken", &stdout);
     assert_snapshot!("search_single_substring_match", snapshot_content);
 }
 
@@ -140,15 +140,15 @@ fn test_search_multiple_terms() {
         r#"{
   "recipes": [
     {
-      "name": "chicken-rice-bowl",
+      "name": "Chicken Rice Bowl",
       "ingredients": [{"ingredient_id": "chicken_breast", "grams": 150}]
     },
     {
-      "name": "beef-rice-stir-fry", 
+      "name": "Beef Rice Stir Fry", 
       "ingredients": [{"ingredient_id": "chicken_breast", "grams": 100}]
     },
     {
-      "name": "chicken-salad",
+      "name": "Chicken Salad",
       "ingredients": [{"ingredient_id": "chicken_breast", "grams": 120}]
     }
   ]
@@ -182,7 +182,7 @@ fn test_search_multiple_terms() {
     let output = assert.get_output();
     let stdout = String::from_utf8_lossy(&output.stdout);
     let snapshot_content = format_test_snapshot(
-        &["chicken-rice-bowl", "beef-rice-stir-fry", "chicken-salad"],
+        &["Chicken Rice Bowl", "Beef Rice Stir Fry", "Chicken Salad"],
         "\"chicken rice\"",
         &stdout,
     );
@@ -200,17 +200,17 @@ fn test_search_multiple_matches() {
         r#"{
   "recipes": [
     {
-      "name": "chicken-rice-bowl",
+      "name": "Chicken Rice Bowl",
       "description": "A balanced meal",
       "ingredients": [{"ingredient_id": "chicken_breast", "grams": 150}]
     },
     {
-      "name": "chicken-salad",
+      "name": "Chicken Salad",
       "description": "Fresh salad", 
       "ingredients": [{"ingredient_id": "chicken_breast", "grams": 120}]
     },
     {
-      "name": "spicy-chicken-curry",
+      "name": "Spicy Chicken Curry",
       "ingredients": [{"ingredient_id": "chicken_breast", "grams": 200}]
     }
   ]
@@ -244,7 +244,7 @@ fn test_search_multiple_matches() {
     let output = assert.get_output();
     let stdout = String::from_utf8_lossy(&output.stdout);
     let snapshot_content = format_test_snapshot(
-        &["chicken-rice-bowl", "chicken-salad", "spicy-chicken-curry"],
+        &["Chicken Rice Bowl", "Chicken Salad", "Spicy Chicken Curry"],
         "chicken",
         &stdout,
     );
@@ -265,7 +265,7 @@ fn test_search_no_matches() {
 
     let output = assert.get_output();
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let snapshot_content = format_test_snapshot(&["chicken-rice-bowl"], "pizza", &stdout);
+    let snapshot_content = format_test_snapshot(&["Chicken Rice Bowl"], "pizza", &stdout);
     assert_snapshot!("search_no_matches", snapshot_content);
 }
 
@@ -283,7 +283,7 @@ fn test_search_case_insensitive() {
 
     let output = assert.get_output();
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let snapshot_content = format_test_snapshot(&["chicken-rice-bowl"], "CHICKEN", &stdout);
+    let snapshot_content = format_test_snapshot(&["Chicken Rice Bowl"], "CHICKEN", &stdout);
     assert_snapshot!("search_case_insensitive", snapshot_content);
 }
 
@@ -622,7 +622,7 @@ fn test_exact_match_disambiguates_substring_conflicts() {
                 ]
             },
             {
-                "name": "rice-bowl",
+                "name": "Rice Bowl",
                 "description": "Rice bowl with protein",
                 "ingredients": [
                     {
@@ -674,7 +674,7 @@ fn test_duplicate_recipe_names_search_behavior() {
         r#"{
         "recipes": [
             {
-                "name": "rice-bowl",
+                "name": "Rice Bowl",
                 "description": "First rice bowl (150g rice)",
                 "ingredients": [{
                     "ingredient_id": "rice",
@@ -682,7 +682,7 @@ fn test_duplicate_recipe_names_search_behavior() {
                 }]
             },
             {
-                "name": "rice-bowl", 
+                "name": "Rice Bowl", 
                 "description": "Second rice bowl (200g rice)",
                 "ingredients": [{
                     "ingredient_id": "rice",

--- a/tests/snapshots/list_recipes__success.snap
+++ b/tests/snapshots/list_recipes__success.snap
@@ -2,7 +2,7 @@
 source: tests/list_recipes.rs
 expression: snapshot_content
 ---
-Available recipes: chicken-rice-bowl
+Available recipes: Chicken Rice Bowl
 $ nutriterm list-recipes
 Available recipes:
-  chicken-rice-bowl - A balanced meal with protein, carbs, and vegetables
+  Chicken Rice Bowl - A balanced meal with protein, carbs, and vegetables

--- a/tests/snapshots/recipe__duplicate_recipe_names_search.snap
+++ b/tests/snapshots/recipe__duplicate_recipe_names_search.snap
@@ -3,7 +3,7 @@ source: tests/recipe.rs
 expression: normalized_stderr
 ---
 Error: Duplicate recipe name found in recipes.jsonc:
-Duplicate recipe name 'rice-bowl' found:
+Duplicate recipe name 'Rice Bowl' found:
   - "First rice bowl (150g rice)"
   - "Second rice bowl (200g rice)"
 

--- a/tests/snapshots/recipe__not_found_with_suggestions.snap
+++ b/tests/snapshots/recipe__not_found_with_suggestions.snap
@@ -2,6 +2,6 @@
 source: tests/recipe.rs
 expression: snapshot_content
 ---
-Available recipes: chicken-rice-bowl
+Available recipes: Chicken Rice Bowl
 $ nutriterm recipe nonexistent-recipe
-No matches for 'nonexistent-recipe'. Available recipes: chicken-rice-bowl
+No matches for 'nonexistent-recipe'. Available recipes: Chicken Rice Bowl

--- a/tests/snapshots/recipe__nutrition_display.snap
+++ b/tests/snapshots/recipe__nutrition_display.snap
@@ -2,9 +2,9 @@
 source: tests/recipe.rs
 expression: snapshot_content
 ---
-Available recipes: chicken-rice-bowl
-$ nutriterm recipe chicken-rice-bowl
-Recipe: chicken-rice-bowl
+Available recipes: Chicken Rice Bowl
+$ nutriterm recipe Chicken Rice Bowl
+Recipe: Chicken Rice Bowl
 
 ╭───────────────────────────┬──────────┬─────────────┬───────────┬───────┬─────────┬────────────╮
 │  Name                     │  Weight  │  Net carbs  │  Protein  │  Fat  │  Fiber  │  Calories  │

--- a/tests/snapshots/recipe__search_case_insensitive.snap
+++ b/tests/snapshots/recipe__search_case_insensitive.snap
@@ -2,9 +2,9 @@
 source: tests/recipe.rs
 expression: snapshot_content
 ---
-Available recipes: chicken-rice-bowl
+Available recipes: Chicken Rice Bowl
 $ nutriterm recipe CHICKEN
-Recipe: chicken-rice-bowl
+Recipe: Chicken Rice Bowl
 
 ╭───────────────────────────┬──────────┬─────────────┬───────────┬───────┬─────────┬────────────╮
 │  Name                     │  Weight  │  Net carbs  │  Protein  │  Fat  │  Fiber  │  Calories  │

--- a/tests/snapshots/recipe__search_exact_match.snap
+++ b/tests/snapshots/recipe__search_exact_match.snap
@@ -2,9 +2,9 @@
 source: tests/recipe.rs
 expression: snapshot_content
 ---
-Available recipes: chicken-rice-bowl
-$ nutriterm recipe chicken-rice-bowl
-Recipe: chicken-rice-bowl
+Available recipes: Chicken Rice Bowl
+$ nutriterm recipe Chicken Rice Bowl
+Recipe: Chicken Rice Bowl
 
 ╭───────────────────────────┬──────────┬─────────────┬───────────┬───────┬─────────┬────────────╮
 │  Name                     │  Weight  │  Net carbs  │  Protein  │  Fat  │  Fiber  │  Calories  │

--- a/tests/snapshots/recipe__search_multiple_matches.snap
+++ b/tests/snapshots/recipe__search_multiple_matches.snap
@@ -2,11 +2,11 @@
 source: tests/recipe.rs
 expression: snapshot_content
 ---
-Available recipes: chicken-rice-bowl, chicken-salad, spicy-chicken-curry
+Available recipes: Chicken Rice Bowl, Chicken Salad, Spicy Chicken Curry
 $ nutriterm recipe chicken
 Multiple recipes found for 'chicken' (3 matches):
-- chicken-rice-bowl
-- chicken-salad
-- spicy-chicken-curry
+- Chicken Rice Bowl
+- Chicken Salad
+- Spicy Chicken Curry
 
 Please be more specific with your search term.

--- a/tests/snapshots/recipe__search_multiple_terms_unique_match.snap
+++ b/tests/snapshots/recipe__search_multiple_terms_unique_match.snap
@@ -2,9 +2,9 @@
 source: tests/recipe.rs
 expression: snapshot_content
 ---
-Available recipes: chicken-rice-bowl, beef-rice-stir-fry, chicken-salad
+Available recipes: Chicken Rice Bowl, Beef Rice Stir Fry, Chicken Salad
 $ nutriterm recipe "chicken rice"
-Recipe: chicken-rice-bowl
+Recipe: Chicken Rice Bowl
 
 ╭────────────────┬──────────┬─────────────┬───────────┬───────┬─────────┬────────────╮
 │  Name          │  Weight  │  Net carbs  │  Protein  │  Fat  │  Fiber  │  Calories  │

--- a/tests/snapshots/recipe__search_no_matches.snap
+++ b/tests/snapshots/recipe__search_no_matches.snap
@@ -2,6 +2,6 @@
 source: tests/recipe.rs
 expression: snapshot_content
 ---
-Available recipes: chicken-rice-bowl
+Available recipes: Chicken Rice Bowl
 $ nutriterm recipe pizza
-No matches for 'pizza'. Available recipes: chicken-rice-bowl
+No matches for 'pizza'. Available recipes: Chicken Rice Bowl

--- a/tests/snapshots/recipe__search_single_substring_match.snap
+++ b/tests/snapshots/recipe__search_single_substring_match.snap
@@ -2,9 +2,9 @@
 source: tests/recipe.rs
 expression: snapshot_content
 ---
-Available recipes: chicken-rice-bowl
+Available recipes: Chicken Rice Bowl
 $ nutriterm recipe chicken
-Recipe: chicken-rice-bowl
+Recipe: Chicken Rice Bowl
 
 ╭───────────────────────────┬──────────┬─────────────┬───────────┬───────┬─────────┬────────────╮
 │  Name                     │  Weight  │  Net carbs  │  Protein  │  Fat  │  Fiber  │  Calories  │


### PR DESCRIPTION
## Summary

- Updates all tests to use human-friendly recipe names like "Chicken Rice Bowl" instead of database-key style names like "chicken-rice-bowl"
- Improves test readability and consistency with user-facing application behavior
- Maintains all existing test functionality while making tests serve as better documentation

## Changes

- **common.rs**: Updated `create_workspace_files()` to use "Chicken Rice Bowl"
- **recipe.rs**: Updated all test cases and recipe references to use human-friendly names
- **list_recipes.rs**: Updated test snapshots to use human-friendly names  
- **Snapshots**: Regenerated all affected snapshots with consistent human-readable naming

## Benefits

- Better test readability and maintainability
- Consistent naming convention across all tests
- Tests now better reflect actual user experience
- Improved documentation value of test cases

Closes #18