### PR TITLE
Fix kitchen-ref scrolling UX with bottom padding

### DIFF
--- a/src/commands/kitchen_ref.rs
+++ b/src/commands/kitchen_ref.rs
@@ -22,5 +22,10 @@ pub fn handle_kitchen_ref_command(data_dir: &Path) -> AppResult<()> {
         println!();
     }
 
+    // Add bottom padding so users can scroll any recipe to the top of their screen
+    // This is especially important for recipes near the end of the list
+    // Using <br/> tags for reliable spacing across all markdown processors
+    println!("{}", "<br/>".repeat(30));
+
     Ok(())
 }

--- a/tests/snapshots/kitchen_ref__markdown_output.snap
+++ b/tests/snapshots/kitchen_ref__markdown_output.snap
@@ -16,3 +16,5 @@ expression: stdout
 - 50.0 g  Feta Cheese
 - 75.0 g  Cherry Tomatoes
 - 60.0 g  Cucumber
+
+<br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>


### PR DESCRIPTION
## Problem

Kitchen-ref markdown output had a subtle but important UX issue: recipes near the bottom of the document couldn't be scrolled to the top of the screen for easy reference while cooking. This made it difficult to focus on recipes at the end of the list.

## Root Cause

Insufficient content below the last recipes meant there wasn't enough scrolling headroom to position them at the top of the viewport.

## Solution

Added 30 `<br/>` tags at the end of kitchen-ref output to provide reliable bottom padding.

### Implementation Details

```rust
// Add bottom padding so users can scroll any recipe to the top of their screen  
// This is especially important for recipes near the end of the list
// Using <br/> tags for reliable spacing across all markdown processors
println!("{}", "<br/>".repeat(30));
```

### Why `<br/>` tags?

- **Reliable**: No dependency on whitespace preservation by markdown processors
- **Semantic**: Explicitly represents line breaks in HTML/markdown  
- **Cross-platform**: Works consistently across all markdown renderers and output formats
- **Snapshot-friendly**: Not trimmed by test frameworks like raw whitespace would be
- **Print-compatible**: Handles well in PDF generation via pandoc

## Benefits

- ✅ **Better cooking workflow**: Any recipe can now be scrolled to screen top for easy reference
- ✅ **Especially helpful for bottom recipes**: Solves the core UX issue 
- ✅ **Clean implementation**: Uses idiomatic `String::repeat()` method
- ✅ **Reliable across formats**: Works in markdown, HTML, and PDF outputs
- ✅ **All tests passing**: No regressions, snapshot properly updated

## User Experience

**Before**: Last few recipes couldn't scroll to top of screen  
**After**: All recipes can be positioned at screen top for easy reference

This subtle but important improvement significantly enhances the kitchen-ref experience for users who print or view the reference while cooking.