### PR TITLE
Add consistent caching to format job in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,15 @@ jobs:
       with:
         components: rustfmt
     
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    
     - name: Check formatting
       run: cargo fmt --all -- --check
 


### PR DESCRIPTION
## Summary
- Add missing cache configuration to the format job to match other CI jobs
- Ensures consistent dependency caching across all 4 CI jobs (test, format, clippy, check-build)

## Changes
- Added cache step to format job with same configuration as other jobs
- All jobs now cache `~/.cargo/registry`, `~/.cargo/git`, and `target` directories

This improves CI consistency and provides minor performance benefits for the format job.