### PR TITLE
Improve function naming: validate_ → check_, generate_ → create_

### DIFF
--- a/src/catalog/storage/initialization.rs
+++ b/src/catalog/storage/initialization.rs
@@ -10,16 +10,16 @@ const INGREDIENT_TEMPLATE: &str = include_str!("ingredients.template.jsonc");
 /// Initialize a complete catalog with all required files and editor support
 pub fn initialize(output_dir: &Path) -> AppResult<()> {
     create_required_files(output_dir)?;
-    generate_all_schemas(output_dir)?;
+    create_all_schemas(output_dir)?;
     Ok(())
 }
 
 /// Schema generators for loader validation (exported to storage module)
-pub(super) fn generate_recipe_schema() -> Value {
+pub(super) fn create_recipe_schema() -> Value {
     serde_json::from_str(RECIPE_SCHEMA).expect("Embedded recipe schema should be valid JSON")
 }
 
-pub(super) fn generate_ingredient_schema() -> Value {
+pub(super) fn create_ingredient_schema() -> Value {
     serde_json::from_str(INGREDIENT_SCHEMA)
         .expect("Embedded ingredient schema should be valid JSON")
 }
@@ -35,11 +35,11 @@ fn create_required_files(output_dir: &Path) -> AppResult<()> {
     Ok(())
 }
 
-/// Generate editor support files (JSON Schema files)
-fn generate_all_schemas(output_dir: &Path) -> AppResult<()> {
+/// Create editor support files (JSON Schema files)
+fn create_all_schemas(output_dir: &Path) -> AppResult<()> {
     std::fs::create_dir_all(output_dir)?;
 
-    let recipe_schema = generate_recipe_schema();
+    let recipe_schema = create_recipe_schema();
     let recipe_schema_path = output_dir.join("recipes.schema.json");
     let recipe_json = serde_json::to_string_pretty(&recipe_schema).map_err(|e| {
         crate::error::AppError::Other(format!(
@@ -50,7 +50,7 @@ fn generate_all_schemas(output_dir: &Path) -> AppResult<()> {
     })?;
     std::fs::write(&recipe_schema_path, recipe_json)?;
 
-    let ingredient_schema = generate_ingredient_schema();
+    let ingredient_schema = create_ingredient_schema();
     let ingredient_path = output_dir.join("ingredients.schema.json");
     let ingredient_json = serde_json::to_string_pretty(&ingredient_schema).map_err(|e| {
         crate::error::AppError::Other(format!(


### PR DESCRIPTION
## Summary

Improves internal function naming consistency by replacing verbose prefixes with shorter, more intuitive alternatives:

- **`validate_` → `check_`**: More concise and equally clear for verification functions
- **`generate_` → `create_`**: Shorter and more direct for construction functions

## Changes Made

### ✅ **`validate_` → `check_` (4 functions):**
- `validate_recipe_uniqueness()` → `check_recipe_uniqueness()`
- `validate_ingredient_uniqueness()` → `check_ingredient_uniqueness()`
- `validate_uniqueness()` → `check_uniqueness()`
- `validate_with_schema()` → `check_with_schema()`

### ✅ **`generate_` → `create_` (3 functions):**
- `generate_recipe_schema()` → `create_recipe_schema()`
- `generate_ingredient_schema()` → `create_ingredient_schema()`
- `generate_all_schemas()` → `create_all_schemas()`

## Benefits

🎯 **Improved Readability:**
- **Shorter, cleaner names** - easier to read and type
- **More intuitive** - "check" implies verification, "create" implies construction
- **Consistent with Rust conventions** - favors concise, clear naming

🔧 **Better Code Flow:**
- Less verbose function names improve code readability
- Maintains the same clear intent while being more concise
- No functional changes - pure naming improvement

## Testing

- ✅ All 36 tests continue to pass
- ✅ No behavioral changes - internal refactoring only
- ✅ Code formatted with `cargo fmt`

This is a small but meaningful improvement to code readability and developer experience.